### PR TITLE
Add compression prototyping scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There is currently no parsable trace-file output, and replaying traces is not po
 ### Usage
 
 This project uses [xboxpy](https://github.com/XboxDev/xboxpy).
-Please read its documentation to find out how to configure it for your Xbox.
+Please read its documentation to find out how to install and configure it for your Xbox.
 
 Afterwards, you can run these commands:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Afterwards, you can run these commands:
 ```
 git clone https://github.com/XboxDev/nv2a-trace.git
 cd nv2a-trace
-python3 nv2a-trace.py
+python3 -u nv2a-trace.py
 ```
 
 The last line will run nv2a-trace and connect to your Xbox.

--- a/Trace.py
+++ b/Trace.py
@@ -15,10 +15,10 @@ def addHTML(xx):
   f.write("<tr>")
   for x in xx:
     f.write("<td>%s</td>" % x)
-  f.write("</tr>")
+  f.write("</tr>\n")
   f.close()
 f = open(debugLog,"w")
-f.write("<html><head><style>body { font-family: sans-serif; background:#333; color: #ccc } img { border: 1px solid #FFF; } td, tr, table { background: #444; padding: 10px; border:1px solid #888; border-collapse: collapse; }</style></head><body><table>")
+f.write("<html><head><style>body { font-family: sans-serif; background:#333; color: #ccc } img { border: 1px solid #FFF; } td, tr, table { background: #444; padding: 10px; border:1px solid #888; border-collapse: collapse; }</style></head><body><table>\n")
 #FIXME: atexit close tags.. but yolo!
 f.close()
 addHTML(["<b>#</b>", "<b>Opcode / Method</b>", "..."])

--- a/compression-estimate.py
+++ b/compression-estimate.py
@@ -1,0 +1,47 @@
+import sys
+
+cache = {}
+
+cache_element_size = 0x10000 # The page size in bytes
+hash_length = 16 # The length of a single hash in bytes
+overhead = cache_element_size // 2 + hash_length # The number of virtual bytes we transfer for each hash lookup
+
+def hash_func(data):
+  return hash(data)
+
+processed_bytes = 0
+pad_bytes = 0
+
+for path in sys.argv[1:]:
+
+  print("Processing '%s'" % path)
+
+  with open(path, 'rb') as f:
+    while True:
+      data = f.read(cache_element_size)
+      if len(data) == 0:
+        break
+      processed_bytes += len(data)
+      pad_size = cache_element_size - len(data)
+      pad_bytes += pad_size
+      data += bytes([0x00]) * pad_size
+      assert(len(data) == cache_element_size)
+      h = hash_func(data)
+      if h in cache:
+        assert(cache[h] == data)
+      else:
+        cache[h] = data
+
+def mb(bytes):
+  return bytes / 1024 / 1024
+
+access_count = processed_bytes // cache_element_size
+
+cache_size = len(cache) * (cache_element_size + hash_length)
+overhead_size = access_count * overhead
+traffic_size = cache_size + overhead_size
+
+print("\nProcessed %.1f MiB and generated %.1f MiB of cache (%d element(s) x %d byte(s) per element), including %.1f MiB padding" % (mb(processed_bytes), mb(cache_size), len(cache), cache_element_size, mb(pad_bytes)))
+print("That's %.1f MiB traffic, including %.1f MiB overhead (%d access(es) x %d bytes)" % (mb(traffic_size), mb(overhead_size), access_count, overhead))
+print("Factor: %.2fx" % (processed_bytes / traffic_size))
+

--- a/compression-test.py
+++ b/compression-test.py
@@ -1,0 +1,105 @@
+from xboxpy import *
+from hashlib import sha1
+from time import perf_counter
+import atexit
+import struct
+
+def get_hash(address, size):
+
+  # We need to reserve a buffer for this structure:
+  #
+  # typedef struct {
+  #   DWORD		FinishFlag;
+  #   BYTE		HashVal[20];
+  #   DWORD state[5];
+  #   DWORD count[2];
+  #   unsigned char buffer[64];
+  # } A_SHA_CTX;
+  sha_size = 4 + 20 + 5 * 4 + 2 * 4 + 64
+  if get_hash.sha_address is None:
+    get_hash.sha_address = ke.MmAllocateContiguousMemory(sha_size + 20)
+    get_hash.sha_clean = read(get_hash.sha_address, sha_size - 64)
+
+  # We need complete blocks, so the hash is always valid without XcSHAFinal.
+  # This means we can retrieve it faster.
+  assert(size % 64 == 0)
+
+  # Writing a custom initialization is faster than doing a call
+  if False:
+    ke.XcSHAInit(get_hash.sha_address)
+  else:
+    write(get_hash.sha_address, get_hash.sha_clean)
+
+  ke.XcSHAUpdate(get_hash.sha_address, address, size)  
+
+  # We can read the result straight from the SHA context
+  if False:
+    sha_value_address = get_hash.sha_address + sha_size
+    ke.XcSHAFinal(get_hash.sha_address, sha_value_address)
+    sha_value = read(sha_value_address, 20)
+  else:
+    #FIXME: This doesn't return a sha1, but something else.
+    #       Would need more logic: https://github.com/NVIDIA/winex_lgpl/blob/master/winex/dlls/advapi32/crypt_sha.c
+    sha_value = read(get_hash.sha_address + 24, 20)
+  return sha_value
+
+@atexit.register
+def free_get_hash():
+  if get_hash.sha_address is not None:
+    ke.MmFreeContiguousMemory(get_hash.sha_address)
+    get_hash.sha_address = None
+
+get_hash.sha_address = None
+
+
+address = 0x11000
+size = 512 * 1024 #0x100000
+
+t0 = perf_counter()
+h1 = get_hash(address, size)
+t1 = perf_counter() 
+h2 = get_hash(address, size)
+t2 = perf_counter()
+h3 = sha1(read(address, size)).digest()
+t3 = perf_counter()
+
+data = read(address, size)
+
+
+def get_hashes(address, size, count=1):
+  data = interface.if_xbdm.xbdm_command("getsum addr=0x%X length=0x%X blocksize=0x%X" % (address, size * count, size), length=count * 4)[1]
+  return struct.unpack("<%dL" % count, data)
+
+import zlib
+print("0x%X" % zlib.crc32(data))
+print("0x%X" % get_hashes(address, size)[0])
+
+d = bytes([0x00] * 8)
+def xboxcrc(d):
+  h = zlib.crc32(d)
+  h ^= 0xFFFFFFFF
+
+  def reverse(x):
+      result = 0
+      for i in range(32):
+          if (x >> i) & 1: result |= 1 << (31 - i)
+      return result
+
+  return reverse(h)
+  
+print("0x%X for 8 x zero" % xboxcrc(d))
+write(address, d)
+print("0x%X" % get_hashes(address, len(d))[0])
+
+
+
+h4 = get_hashes(address, size // 16, 16)
+t4 = perf_counter()
+
+
+print("Hashed %d bytes" % size)
+print("Initialization: %.2f ms [%s]" % ((t1 - t0) * 1000, h1.hex()))
+print("Hash on Xbox:   %.2f ms [%s]" % ((t2 - t1) * 1000, h2.hex()))
+print("Hash on Host:   %.2f ms [%s]" % ((t3 - t2) * 1000, h3.hex()))
+print("Hash in XBDM:   %.2f ms %s" % ((t4 - t3) * 1000, str(list(hex(x) for x in h4))))
+

--- a/nv2a-trace.py
+++ b/nv2a-trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3 -u
 
 from xboxpy import *
 


### PR DESCRIPTION
* compression-estimate.py attempts to calculate what kind of speedup we could expect when using compression. The virtual overhead measured in bytes (instead of milliseconds) makes this very hard to work with.
* compression-test.py can be used to prototype different hashing methods, measure XBDM performance etc.

Please leave a comment if you have questions or comments!