### PR TITLE
NV tile decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There is currently no parsable trace-file output, and replaying traces is not po
 ### Usage
 
 This project uses [xboxpy](https://github.com/XboxDev/xboxpy).
-Please read its documentation to find out how to configure it for your Xbox.
+Please read its documentation to find out how to install and configure it for your Xbox.
 
 Afterwards, you can run these commands:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Afterwards, you can run these commands:
 ```
 git clone https://github.com/XboxDev/nv2a-trace.git
 cd nv2a-trace
-python3 nv2a-trace.py
+python3 -u nv2a-trace.py
 ```
 
 The last line will run nv2a-trace and connect to your Xbox.

--- a/Trace.py
+++ b/Trace.py
@@ -15,10 +15,10 @@ def addHTML(xx):
   f.write("<tr>")
   for x in xx:
     f.write("<td>%s</td>" % x)
-  f.write("</tr>")
+  f.write("</tr>\n")
   f.close()
 f = open(debugLog,"w")
-f.write("<html><head><style>body { font-family: sans-serif; background:#333; color: #ccc } img { border: 1px solid #FFF; } td, tr, table { background: #444; padding: 10px; border:1px solid #888; border-collapse: collapse; }</style></head><body><table>")
+f.write("<html><head><style>body { font-family: sans-serif; background:#333; color: #ccc } img { border: 1px solid #FFF; } td, tr, table { background: #444; padding: 10px; border:1px solid #888; border-collapse: collapse; }</style></head><body><table>\n")
 #FIXME: atexit close tags.. but yolo!
 f.close()
 addHTML(["<b>#</b>", "<b>Opcode / Method</b>", "..."])

--- a/nv2a-trace.py
+++ b/nv2a-trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3 -u
 
 from xboxpy import *
 

--- a/nv_tiles.py
+++ b/nv_tiles.py
@@ -103,15 +103,29 @@ class mc_config:
       self.partbits = 2
       self.colbits_lo = 2
       self.burstbits = 0
-
+      #FIXME: !!!!!
+      #FIXME: This is still incomplete
+      #FIXME: !!!!!
 
 def tile_translate_addr(chipset, pitch, address, mode, bankoff, mcc):
+
+  #FIXME: !!!!!
+  #FIXME: mode is always 1 pre PFB_NV40 (?) according to mwk
+  #FIXME: !!!!!
   bankshift = mcc.mcbits + mcc.partbits + mcc.colbits_lo
   is_vram = (mode == 1) or (mode == 4)
   if (is_igp(chipset)):
     is_vram = 0
+
+
+  #FIXME: !!!!!
+  #FIXME: You'd think that this would always be taken for NV2A
+  #       However, NV2A is not really an IGP, so this might not be taken!
+  #       So, this needs further testing / analysis.
+  #FIXME: !!!!!
   if (is_vram == False):
     bankshift = 12
+
 
   valid, shift, factor = tile_pitch_valid(chipset, pitch)
   if (valid == False):
@@ -131,6 +145,13 @@ def tile_translate_addr(chipset, pitch, address, mode, bankoff, mcc):
 
   fb_type = pfb_type(chipset)
   if fb_type == PFB_NV10:
+
+    #FIXME: !!!!!
+    #FIXME: @MoochMcGee said that this NV10 codepath can probably be removed.
+    #       So if we do it, and it's bad, then blame it all on @MoochMcGee
+    #       (she said: "lol fair enough")
+    #FIXME: !!!!!
+
     iy = address >> (shift + 8) & ((1 << (bankshift - 8)) - 1)
     iaddr = ix | iy << 8
     if (y & 1):
@@ -154,6 +175,11 @@ def tile_translate_addr(chipset, pitch, address, mode, bankoff, mcc):
       part += 1 << (mcc.partbits - 2)
     part &= (1 << mcc.partbits) - 1
     if (chipset >= 0x30):
+
+      #FIXME: !!!!!
+      #FIXME: Will never be taken for NV2A
+      #FIXME: !!!!!
+
       bank = baddr & 3
       if (shift >= 2):
         bank ^= y << 1 & 2

--- a/nv_tiles.py
+++ b/nv_tiles.py
@@ -1,0 +1,223 @@
+# Based on https://github.com/envytools/envytools/blob/master/nvhw/tile.c
+
+def is_igp(chipset):
+  #  switch (chipset) {
+  #    case 0x0a:
+  #    case 0x1a:
+  #    case 0x1f:
+  #    case 0x2a:
+  #    case 0x4e:
+  #    case 0x4c:
+  #    case 0x67:
+  #    case 0x68:
+  #    case 0x63:
+  #    case 0xaa:
+  #    case 0xac:
+  #    case 0xaf:
+  #      return 1;
+  #    default:
+  #      return 0;
+  #  }
+
+  # Hack, based on the following IRC discussion:
+  #  mwk: JayFoxRox: don't treat the NV2A as an IGP
+  #  mwk: it might be an IGP by definition, but the xbox.... is very strange
+  #  mwk: in normal IGP setup, the GPU borrows memory from the main mem controller, but in xbox, it's the other way around -- all the memory in the xbox is VRAM, and the CPU borrows it
+  #  mwk: so the memory controller is pretty much identical to a normal discrete GPU
+  #  JayFoxRox: mwk: NV2A is chipset 0x2A, correct? so should I make is_igp return False in my use-case?
+  #  mwk: is_igp... I guess it'd be OK to make is_igp false
+  #  mwk: though it might be better to tie that to PFB type instead
+
+  return False
+
+def has_tile_factor_13(chipset):
+  # return pfb_type(chipset) >= PFB_NV20 && chipset != 0x20
+
+  # Not sure if NV2A / 0x2A actually qualifies, because it's before 0x25
+  assert(False)
+
+  return True
+
+def has_large_tile(chipset):
+  # return pfb_type(chipset) == PFB_NV40 || pfb_type(chipset) == PFB_NV41
+  return False
+
+PFB_NV10 = 1
+PFB_NV20 = 2
+PFB_NV44 = 3
+
+def pfb_type(chipset):
+  return PFB_NV20
+
+def tile_pitch_valid(chipset, pitch):
+
+  if (pitch & ~0x1ff00):
+    return False, 0, 0
+
+  pitch >>= 8
+  if (pitch == 0):
+    return False, 0, 0
+
+  if (pitch == 1):
+    return False, 0, 0
+  if (pitch & 1) and ((pfb_type(chipset) == PFB_NV10) or (pfb_type(chipset) == PFB_NV44)):
+    return False, 0, 0
+  if (pitch > 0x100):
+    return False, 0, 0
+
+  shift = 0
+  while ((pitch & 1) == 0):
+    pitch >>= 1
+    shift += 1
+
+  if (shift >= 8) and has_large_tile(chipset) == False:
+    return False, 0, 0
+
+  if (pitch == 1):
+    factor = 0
+  elif (pitch == 3):
+    factor = 1
+  elif (pitch == 5):
+    factor = 2
+  elif (pitch == 7):
+    factor = 3
+  elif (pitch == 13):
+    if has_tile_factor_13(chipset) == False:
+      return False, 0, 0
+    factor = 4
+  else:
+    return False, 0, 0
+
+  return True, shift, factor
+
+class mc_config:
+  def __init__(self, cfg0, cfg1):
+    self.mcbits = 0
+    self.partbits = 0
+    self.colbits_lo = 0
+    self.burstbits = 0
+
+    if True:
+      #FIXME: Add https://github.com/envytools/envytools/blob/master/hwtest/nv10_tile.cc#L35
+      self.mcbits = 2
+      self.partbits = 2
+      self.colbits_lo = 2
+      self.burstbits = 0
+
+
+def tile_translate_addr(chipset, pitch, address, mode, bankoff, mcc):
+  bankshift = mcc.mcbits + mcc.partbits + mcc.colbits_lo
+  is_vram = (mode == 1) or (mode == 4)
+  if (is_igp(chipset)):
+    is_vram = 0
+  if (is_vram == False):
+    bankshift = 12
+
+  valid, shift, factor = tile_pitch_valid(chipset, pitch)
+  if (valid == False):
+    assert(False)
+
+  x = address % pitch
+  y = address // pitch
+  ix = x & 0xff
+  iy = y & ((1 << (bankshift - 8)) - 1)
+
+  x >>= 8
+  y >>= bankshift - 8
+  iaddr = 0
+  baddr = y * (pitch >> 8) + x
+  part = 0
+  tag = 0
+
+  fb_type = pfb_type(chipset)
+  if fb_type == PFB_NV10:
+    iy = address >> (shift + 8) & ((1 << (bankshift - 8)) - 1)
+    iaddr = ix | iy << 8
+    if (y & 1):
+      baddr ^= 1
+    if (chipset > 0x10) and (mcc.mcbits + mcc.partbits + mcc.burstbits > 4) and (address & 0x100):
+      iaddr ^= 0x10
+    if (ppart or ptag):
+      assert(False)
+  elif fb_type == PFB_NV20:
+    x1 = ix & 0xf
+    ix >>= 4
+    part = ix & ((1 << mcc.partbits) - 1)
+    ix >>= mcc.partbits
+    x2 = ix
+    y1 = iy & 3
+    iy >>= 2
+    y2 = iy
+    if (y2 & 1) and (mcc.partbits >= 1):
+      part += 1 << (mcc.partbits - 1)
+    if (y2 & 2) and (mcc.partbits >= 2):
+      part += 1 << (mcc.partbits - 2)
+    part &= (1 << mcc.partbits) - 1
+    if (chipset >= 0x30):
+      bank = baddr & 3
+      if (shift >= 2):
+        bank ^= y << 1 & 2
+      if (shift >= 1):
+        bank += y >> 1 & 1
+      bank ^= bankoff
+      bank &= 3
+      baddr = (baddr & ~3) | bank
+    else:
+      baddr ^= bankoff
+      if (y & 1) and shift:
+        baddr ^= 1
+    iaddr = y2
+
+    iaddr <<= 4 - mcc.partbits
+    iaddr |= x2
+    
+    iaddr <<= 2
+    iaddr |= y1
+
+    iaddr <<= mcc.partbits
+    iaddr |= part
+
+    iaddr <<= 4
+    iaddr |= x1
+
+    tag = x + y * (pitch >> 8)
+
+    tag <<= bankshift - 10
+    tag |= iy
+
+    tag <<= (4 - mcc.partbits)
+    tag |= x2
+
+  else:
+    assert(False)
+
+  return tag, part, (iaddr | baddr << bankshift)
+
+
+if False:
+  chipset = 0x2A
+  pitch = 2560
+
+  #FIXME: Where to get these from? - probably NV_PFB_CFG0 / NV_PFB_CFG1 ?
+  mode = 1
+  bankoff = 0
+  mcc = mc_config()
+  mcc.mcbits = 2
+  mcc.partbits = 2
+  mcc.colbits_lo = 2
+  mcc.burstbits = 0
+
+  #<li>2 bits selecting byte inside a memory cell</li>
+  #<li>2 bits selecting a column</li>
+  #<li>0-2 more bits selecting byte inside a memory cell [depending on bus width]</li>
+  #<li>6-8 more bits selecting a column</li>
+  #<li>1 bit selecting a bank</li>
+  #<li>8-12 bits selecting a row</li>
+  #<li>0-1 more bits selecting a bank</li>
+
+  for i in range(640*480):
+    address = i
+    out_address = tile_translate_addr(chipset, pitch, address * 4, mode, bankoff, mcc)
+    print("%d: %d" % (address, out_address[2] // 4))
+
+


### PR DESCRIPTION
This was started, but then I decided to just disable tiling on the Xbox GPU as a workaround.
Tiling in nv2a-trace and XQEMU will only cause more performance issue, and it's not too critical for now anyway.

The code was mostly stolen from nouveau. Special thanks to mwk et. al. for being super helpful!


---

Here is an example (Ripped from 0a8ae3031a230adca481a652fe28308ab94a4873 decode-state.py):

```python


# This configures how tiling works
cfg0 = read_word(nv2a_mem, 0x100200)
cfg1 = read_word(nv2a_mem, 0x100204)
mcc = nv_tiles.mc_config(cfg0, cfg1)



# Requirement for the tiling stuff?
#FIXME: Why tho?
height = align_up(height, 16)

bpp = int(sys.argv[2])




def untile(data, lookup, bpp):
  bytes_per_pixel = bpp // 8
  new_data = bytearray(data)
  for i in lookup:
    for j in range(bytes_per_pixel):
      new_data[i * bytes_per_pixel + j] = data[lookup[i] * bytes_per_pixel + j]
  return new_data





# These are assumptions, need to look at envytools to confirm
chipset = 0x2A
bankoff = 0

# This does not matter
mode = 0


bytes_per_pixel = bpp // 8

if False:
  color_tile_lookup = []
  for i in range(pitch * height // bytes_per_pixel):
    color_tile_lookup += [nv_tiles.tile_translate_addr(chipset, color_pitch, i * bytes_per_pixel, mode, bankoff, mcc)[2] // bytes_per_pixel]

  depth_tile_lookup = []
  for i in range(pitch * height // bytes_per_pixel):
    depth_tile_lookup += [nv_tiles.tile_translate_addr(chipset, depth_pitch, i * bytes_per_pixel, mode, bankoff, mcc)[2] // bytes_per_pixel]



assert(height % 16 == 0)

if mem_color:
  mem_untiled = mem_color #untile(mem_color, color_tile_lookup, bpp)
  img = Texture.decodeTexture(mem_untiled, (width, height), color_pitch, False, bpp, (8,8,8), (16,8,0))
  img.save("untiled-tiles-color.png")

  ImageDraw.Draw(img).rectangle([clip_x - 1, clip_y - 1, clip_x + clip_w + 1, clip_y + clip_h + 1], fill=None, outline=(255, 0, 0))
  img.save("untiled-tiles-color-surface_clip.png")


if mem_depth:
  mem_untiled = mem_depth #untile(mem_depth, depth_tile_lookup, bpp)
  img = Texture.decodeTexture(mem_untiled, (width, height), depth_pitch, False, bpp, (8,8,8), (24,24,24))
  img.save("untiled-tiles-depth.png")

  mem_untiled = mem_depth #untile(mem_depth, depth_tile_lookup, bpp)
  img = Texture.decodeTexture(mem_untiled, (width, height), depth_pitch, False, bpp, (8,8,8), (0,0,0))
img.save("untiled-tiles-stencil.png")
```


